### PR TITLE
feature/run-mcp-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# data dir
+data/
+
+# build artifacts
+*.tar
+*.tar.gz
+*.zip
+
+# docker
+.docker/
+docker-compose.override.yml
+
+# OS files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+*.sublime-*
+
+# temp files
+*.tmp
+*.temp
+*.log
+*.pid
+
+# backup files
+*.bak
+*.backup
+*.old
+
+# python
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+venv/
+env/
+.venv
+
+# requirements / BRD
+requirements.md
+
+# notes
+notes.md

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm
 
 LABEL maintainer="torerodev <opensource@itential.com>"
 LABEL org.opencontainers.image.source="https://github.com/torerodev/torero-container"
-LABEL org.opencontainers.image.description="torero docker image"
+LABEL org.opencontainers.image.description="torero container image"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # default locale
@@ -25,6 +25,20 @@ ENV ENABLE_SSH_ADMIN=false
 # torero eula auto-acceptance is enabled by default
 ENV TORERO_APPLICATION_AUTO_ACCEPT_EULA=true
 
+# MCP server is disabled by default
+ENV ENABLE_MCP=false
+
+# MCP server default configuration
+ENV TORERO_MCP_TRANSPORT_TYPE=sse
+ENV TORERO_MCP_TRANSPORT_HOST=0.0.0.0
+ENV TORERO_MCP_TRANSPORT_PORT=8080
+ENV TORERO_MCP_TRANSPORT_PATH=/sse
+ENV TORERO_API_BASE_URL=http://localhost:8000
+ENV TORERO_API_TIMEOUT=30
+ENV TORERO_LOG_LEVEL=INFO
+ENV TORERO_MCP_PID_FILE=/tmp/torero-mcp.pid
+ENV TORERO_MCP_LOG_FILE=/home/admin/.torero-mcp.log
+
 # reduce docker image size
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -38,6 +52,9 @@ RUN chmod +x /configure.sh && /configure.sh && \
 
 # expose ssh port (only used if SSH is enabled)
 EXPOSE 22
+
+# expose MCP port (only used if MCP is enabled)
+EXPOSE 8080
 
 # create volume for persistent data
 VOLUME ["/home/admin/data"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Container image for [torero](https://torero.dev), built using vendor-neutral Con
 - Optional [OpenTofu](https://opentofu.org/) installation at runtime
 - Optional SSH administration for testing convenience + labs
 - Optional [torero-api](https://github.com/torerodev/torero-api) launcher for API access
+- Optional [torero-mcp](https://github.com/torerodev/torero-mcp) launcher for Model Context Protocol server
 
 ## Inspiration
 Managing and automating a hybrid, _multi-vendor_ infrastrcuture that encompasses _on-premises systems, private and public clouds, edge computing, and colocation environments_ poses significant challenges. How can you experiment to _learn_ without breaking things? How can you test new and innovative products like _torero_ on the test bench without friction to help in your evaluation? How do you test the behavior of changes in lower level environments before making changes to production? I use [containerlab](https://containerlab.dev/) for all of the above! This project makes it easy to insert _torero_ in your _containerlab_ topology file, connect to the container, and run your experiments -- the sky is the limit!
@@ -35,13 +36,15 @@ services:
     image: ghcr.io/torerodev/torero-container:latest
     container_name: torero
     ports:
+      - "22:22"                # use when ENABLE_SSH_ADMIN=true
       - "8000:8000"            # use when ENABLE_API=true
-      - "2222:22"              # use when ENABLE_SSH_ADMIN=true
+      - "8080:8080"            # use when ENABLE_MCP=true
     volumes:
       - ./data:/home/admin/data
     environment:
       - ENABLE_API=true        # enable and run torero api
-      - API_PORT=8001          # api port (default: 8000)
+      - API_PORT=8000          # api port
+      - ENABLE_MCP=true        # enable torero-mcp server
       - ENABLE_SSH_ADMIN=true  # enable ssh admin at runtime
       - INSTALL_OPENTOFU=true  # enable OpenTofu installation at runtime
       - OPENTOFU_VERSION=1.9.0
@@ -72,10 +75,26 @@ The following environment variables can be set at runtime:
 |----------|---------|-------------|
 | `ENABLE_API`       | `false`  | Enable torero API       |
 | `API_PORT`         | `8000`   | Set API port            |
+| `ENABLE_MCP`       | `false`  | Enable torero MCP server|
 | `ENABLE_SSH_ADMIN` | `false`  | Enable SSH admin user   |
 | `INSTALL_OPENTOFU` | `true`   | Install OpenTofu        |
 | `OPENTOFU_VERSION` | `1.9.0`  | Set OpenTofu version    |
 | `PYTHON_VERSION`   | `3.13.0` | Set Python version      |
+
+#### MCP Server Environment Variables
+When `ENABLE_MCP=true`, the following additional environment variables are available:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TORERO_MCP_TRANSPORT_TYPE` | `sse` | MCP transport type |
+| `TORERO_MCP_TRANSPORT_HOST` | `0.0.0.0` | MCP server host |
+| `TORERO_MCP_TRANSPORT_PORT` | `8080` | MCP server port |
+| `TORERO_MCP_TRANSPORT_PATH` | `/sse` | SSE endpoint path |
+| `TORERO_API_BASE_URL` | `http://localhost:8000` | torero API base URL |
+| `TORERO_API_TIMEOUT` | `30` | API request timeout in seconds |
+| `TORERO_LOG_LEVEL` | `INFO` | Logging level |
+| `TORERO_MCP_PID_FILE` | `/tmp/torero-mcp.pid` | PID file location |
+| `TORERO_MCP_LOG_FILE` | `/home/admin/.torero-mcp.log` | Log file path |
 
 ## CLI runner script
 The _cli-runner.sh_ script provides a convenient way to run, test, and do house cleaning locally when running on your workstation. I use it for quick and dirty testing 🚀
@@ -92,6 +111,12 @@ The _cli-runner.sh_ script provides a convenient way to run, test, and do house 
 
 # run with torero-api on custom port
 ./cli-runner.sh --run --enable-api --api-port 8001
+
+# run with torero-mcp enabled on default port 8080
+./cli-runner.sh --run --enable-mcp
+
+# run with torero-mcp on custom port
+./cli-runner.sh --run --enable-mcp --mcp-port 9080
 
 # check status
 ./cli-runner.sh --status

--- a/configure.sh
+++ b/configure.sh
@@ -48,6 +48,7 @@ install_packages() {
         iputils-ping \
         iproute2 \
         net-tools \
+        procps \
         unzip \
         file \
         locales \


### PR DESCRIPTION
# ✨ Feature: torero-mcp Service

## 📒 Summary
This PR adds support for running torero-mcp (Model Context Protocol) server in daemon mode within the torero container. The MCP server enables AI integrations by providing a standardized protocol for AI models to interact with torero. When enabled, the MCP server runs alongside the torero-api, providing SSE (Server-Sent Events) transport for real-time communication with AI clients.

## 🔧 Changes
- Added `setup_torero_mcp()` function to entrypoint.sh for MCP daemon management
- Added ENABLE_MCP environment variable (default: false) to control MCP server startup
- Added MCP configuration environment variables for transport, host, port, and logging
- Updated Containerfile to expose port 8080 for MCP server and include all MCP-related environment variables
- Added procps package to configure.sh for process management (pgrep) support
- Implemented health check logic to ensure torero-api is ready before starting MCP
- Updated README.md with MCP configuration documentation and examples