### PR TITLE
release/v1.5.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # Default versions; Override with env variables
-TORERO_VERSION=1.4.0
+TORERO_VERSION=1.5.0
 PYTHON_VERSION=3.13.0
 OPENTOFU_VERSION=1.10.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
       torero_version:
         description: 'torero version to build'
         required: true
-        default: '1.4.0'
+        default: '1.5.0'
       python_version:
         description: 'Python version to install'
         required: true
@@ -29,7 +29,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: torerodev/torero-container
-  DEFAULT_TORERO_VERSION: '1.4.0'  # Update this when new torero versions are released
+  DEFAULT_TORERO_VERSION: '1.5.0'  # Update this when new torero versions are released
 
 jobs:
 

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 # default version
-ARG TORERO_VERSION=1.4.0
+ARG TORERO_VERSION=1.5.0
 ENV TORERO_VERSION=${TORERO_VERSION}
 
 # OpenTofu default version - can be overridden at runtime with OPENTOFU_VERSION env var

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GHCR_REGISTRY ?= ghcr.io/torerodev
 
 # default versions if not specified (fallback if .env is missing)
 # override with 'make build TORERO_VERSION=x.x.x'
-TORERO_VERSION ?= 1.4.0
+TORERO_VERSION ?= 1.5.0
 
 # default python version
 PYTHON_VERSION ?= 3.13.0
@@ -46,7 +46,7 @@ PLATFORMS ?= linux/amd64,linux/arm64
 LOCAL_PLATFORM ?= linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 # all available torero versions for build-all
-TORERO_VERSIONS ?= 1.4.0
+TORERO_VERSIONS ?= 1.5.0
 
 help:
 	@echo "available targets:"
@@ -60,7 +60,7 @@ help:
 	@echo ""
 	@echo "variables:"
 	@echo "  GHCR_REGISTRY     - github container registry path (default: ghcr.io/torerodev)"
-	@echo "  TORERO_VERSION    - torero version to build (default: 1.4.0)"
+	@echo "  TORERO_VERSION    - torero version to build (default: 1.5.0)"
 	@echo "  PYTHON_VERSION    - python version to install (default: 3.13.0)"
 	@echo "  TORERO_VERSIONS   - space-separated list of torero versions for build-all (default: 1.3.1)"
 	@echo "  FORCE_REBUILD     - set to 'true' to force rebuild (default: false)"
@@ -70,9 +70,9 @@ help:
 	@echo ""
 	@echo "examples:"
 	@echo "  make build"
-	@echo "  make build TORERO_VERSION=1.4.0 PYTHON_VERSION=3.13.0"
+	@echo "  make build TORERO_VERSION=1.5.0 PYTHON_VERSION=3.13.0"
 	@echo "  make build-multi PLATFORMS=linux/amd64,linux/arm64"
-	@echo "  make build-all TORERO_VERSIONS=\"1.3.1 1.4.0\""
+	@echo "  make build-all TORERO_VERSIONS=\"1.4.0 1.5.0\""
 	@echo "  make push"
 	@echo "  make push-all"
 

--- a/README.md
+++ b/README.md
@@ -119,19 +119,19 @@ The container will automatically download and install the requested version at s
 
 ```bash
 # start all services with development configuration
-docker-compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml up -d
 
 # stop services
-docker-compose -f docker-compose.dev.yml down
+docker compose -f docker-compose.dev.yml down
 
 # rebuild and start
-docker-compose -f docker-compose.dev.yml up --build -d
+docker compose -f docker-compose.dev.yml up --build -d
 
 # view logs
-docker-compose -f docker-compose.dev.yml logs -f
+docker compose -f docker-compose.dev.yml logs -f
 
 # clean up everything
-docker-compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.dev.yml down -v
 ```
 
 ### Using tools.sh for development tasks

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,9 @@
 ---
 services:
   torero:
-    build: .
+    build:
+      context: .
+      dockerfile: Containerfile
     image: torero-local
     container_name: torero
     ports:

--- a/push.sh
+++ b/push.sh
@@ -25,8 +25,8 @@ fi
 usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
-    echo "  -v, --version VERSION              Container version (default: ${VERSION:-1.4.0})"
-    echo "  -t, --torero-version VERSION       Torero version (default: ${TORERO_VERSION:-1.4.0})"
+    echo "  -v, --version VERSION              Container version (default: ${VERSION:-1.5.0})"
+    echo "  -t, --torero-version VERSION       Torero version (default: ${TORERO_VERSION:-1.5.0})"
     echo "  -p, --python-version VERSION       Python version (default: ${PYTHON_VERSION:-3.13.0})"
     echo "  -o, --opentofu-version VERSION     OpenTofu version (default: ${OPENTOFU_VERSION:-1.10.5})"
     echo "  -u, --username USERNAME            GitHub username"
@@ -96,8 +96,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # prompt for missing values
-prompt_for_value "VERSION" "Enter container version" "${VERSION:-1.4.0}"
-prompt_for_value "TORERO_VERSION" "Enter Torero version" "${TORERO_VERSION:-1.4.0}"
+prompt_for_value "VERSION" "Enter container version" "${VERSION:-1.5.0}"
+prompt_for_value "TORERO_VERSION" "Enter Torero version" "${TORERO_VERSION:-1.5.0}"
 prompt_for_value "PYTHON_VERSION" "Enter Python version" "${PYTHON_VERSION:-3.13.0}"
 prompt_for_value "OPENTOFU_VERSION" "Enter OpenTofu version" "${OPENTOFU_VERSION:-1.10.5}"
 prompt_for_value "GITHUB_USERNAME" "Enter GitHub username"


### PR DESCRIPTION
## ✨ release: Update default torero version from 1.4.0 to 1.5.0

## 📒 Summary
Updates the default torero version throughout the project from 1.4.0 to 1.5.0 to align with the latest release.
## 🔧 Changes
- Updated default `TORERO_VERSION` from 1.4.0 to 1.5.0 in:
  - `Containerfile` - Default ARG for container builds
  - `.env` - Default environment variable
  - `Makefile` - Default version and examples
  - `push.sh` - Default version prompts and help text
  - `.github/workflows/publish.yml` - CI/CD workflow defaults
  - `config/architecture.md` - Documentation reference

## 🧪 Testing
To test these changes:
- Build the container locally: `make build`
- Verify torero version: `docker run --rm ghcr.io/torerodev/torero:1.5.0 torero version`
- Run the test suite: `make test`