### PR TITLE
bugfix/mcp-runtime-failure

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     image: torero-local
     container_name: torero
     ports:
-      - "22:22"
+      - "2222:22"
       - "8001:8001"
       - "8080:8080"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/torerodev/torero-container:latest
     container_name: torero
     ports:
-      - "22:22"
+      - "2222:22"
       - "8001:8001"
       - "8080:8080"
     volumes:

--- a/opt/torero-mcp/torero_mcp/executor.py
+++ b/opt/torero-mcp/torero_mcp/executor.py
@@ -155,8 +155,15 @@ class ToreroExecutor:
         raw_output = await self.execute_command(["get", "services", "--raw"])
         
         # handle different response formats
-        if isinstance(raw_output, dict) and "items" in raw_output:
-            return raw_output["items"]
+        if isinstance(raw_output, dict):
+            if "items" in raw_output:
+                return raw_output["items"]
+            elif "services" in raw_output:
+                return raw_output["services"]
+            else:
+
+                # if dict has no known key, raise error
+                raise ToreroExecutorError(f"unexpected json structure: dict with keys {list(raw_output.keys())}")
         elif isinstance(raw_output, list):
             return raw_output
         else:
@@ -186,10 +193,15 @@ class ToreroExecutor:
         """get all decorators."""
         raw_output = await self.execute_command(["get", "decorators", "--raw"])
         
-        if isinstance(raw_output, dict) and "decorators" in raw_output:
-            return raw_output["decorators"]
-        elif isinstance(raw_output, dict) and "items" in raw_output:
-            return raw_output["items"]
+        if isinstance(raw_output, dict):
+            if "decorators" in raw_output:
+                return raw_output["decorators"]
+            elif "items" in raw_output:
+                return raw_output["items"]
+            else:
+
+                # if dict has no known key, raise error
+                raise ToreroExecutorError(f"unexpected json structure: dict with keys {list(raw_output.keys())}")
         elif isinstance(raw_output, list):
             return raw_output
         else:
@@ -220,8 +232,18 @@ class ToreroExecutor:
         """get all secrets."""
         raw_output = await self.execute_command(["get", "secrets", "--raw"])
         
-        if isinstance(raw_output, dict) and "items" in raw_output:
-            return raw_output["items"]
+        if isinstance(raw_output, dict):
+            if "items" in raw_output:
+                return raw_output["items"]
+            elif "secrets" in raw_output:
+                return raw_output["secrets"]
+            elif "names" in raw_output:
+                # Handle case where only names are returned
+                return raw_output["names"]
+            else:
+
+                # if dict has no known key, raise error
+                raise ToreroExecutorError(f"unexpected json structure: dict with keys {list(raw_output.keys())}")
         elif isinstance(raw_output, list):
             return raw_output
         else:
@@ -236,8 +258,15 @@ class ToreroExecutor:
         """get all registries."""
         raw_output = await self.execute_command(["get", "registries", "--raw"])
         
-        if isinstance(raw_output, dict) and "items" in raw_output:
-            return raw_output["items"]
+        if isinstance(raw_output, dict):
+            if "items" in raw_output:
+                return raw_output["items"]
+            elif "registries" in raw_output:
+                return raw_output["registries"]
+            else:
+
+                # if dict has no known key, raise error
+                raise ToreroExecutorError(f"unexpected json structure: dict with keys {list(raw_output.keys())}")
         elif isinstance(raw_output, list):
             return raw_output
         else:


### PR DESCRIPTION
## 📒 Summary
Fixes the MCP runtime failure where service listing operations were failing with "unexpected json structure: <class 'dict'>" errors. The issue was caused by mismatched JSON response format expectations between the ToreroExecutor and the actual torero CLI output format.

## 🔧 Changes
- **Fixed JSON parsing in ToreroExecutor methods:**
  - `get_services()` - Now handles both "items" and "services" keys  
  - `get_decorators()` - Now handles both "items" and "decorators" keys
  - `get_secrets()` - Now handles "items", "secrets", and "names" keys
  - `get_registries()` - Now handles both "items" and "registries" keys
- **Improved error messages** - Show available keys when JSON structure is unexpected
- **Updated docker-compose port mappings** - Changed SSH from port 22 to 2222 to avoid OrbStack conflicts

## 🧪 Testing
- Verified torero CLI returns `{"services": []}` format, not `{"items": []}` 
- Created and ran comprehensive test script covering all affected methods
- All MCP service listing operations now return proper responses instead of errors
- Container builds and runs successfully with SSH accessible on port 2222

## 🔗 Useful Links
- Issue reported via Claude Desktop MCP connection failures
- Related to recent torero CLI output format changes
- Fixes compatibility with current torero v1.5.0 CLI responses
- Branch: `bugfix/mcp-runtime-failure`
- Commit: `8e0c2cb`