### PR TITLE
bugfix/ui-output-formatting

### DIFF
--- a/opt/torero-ui/torero_ui/static/css/dashboard.css
+++ b/opt/torero-ui/torero_ui/static/css/dashboard.css
@@ -676,7 +676,8 @@ body {
     font-family: 'Consolas', 'Courier New', monospace;
     font-size: 13px;
     line-height: 1.6;
-    white-space: pre;
+    white-space: pre-wrap;
+    word-wrap: break-word;
     border: 1px solid #3c3836;
     max-height: 600px;
     overflow-y: auto;

--- a/opt/torero-ui/torero_ui/templates/dashboard/base.html
+++ b/opt/torero-ui/torero_ui/templates/dashboard/base.html
@@ -37,6 +37,6 @@
     </div>
     
     {% block extra_js %}{% endblock %}
-    <script src="{% static 'js/dashboard.js' %}"></script>
+    <script src="{% static 'js/dashboard.js' %}?v={% now 'U' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
# ✨ Fix: UI output formatting for OpenTofu executions

## 📒 Summary
Fixed JSON output formatting issue in the torero UI where OpenTofu execution results were displayed as raw JSON instead of properly formatted console output. The issue was caused by nested JSON structure where execution data contained a stringified JSON object with the actual stdout/stderr content.

## 🔧 Changes
- Modified `showExecutionDetails()` to parse nested JSON in execution_data when it's a string
- Updated `generateExecutionDetailHTML()` to detect and handle nested JSON structure in execution_data.stdout
- Enhanced `formatConsoleOutput()` to properly parse and format execution output with timing information
- Improved `formatTimingInfo()` to display execution details in a clean format matching CLI output
- Added logic to auto-detect OpenTofu executions and apply appropriate formatting
- Implemented cache-busting for JavaScript file to ensure updates are loaded
- Cleaned up code style to match project conventions (lowercase comments, minimal debug logging)

## 🧪 Testing
- Tested with OpenTofu plan executions displaying nested JSON output
- Verified proper formatting of stdout with ANSI color code conversion
- Confirmed execution timing details display correctly
- Tested cache clearing and browser refresh to ensure changes take effect
- Validated that CLI and UI output now match in formatting quality